### PR TITLE
ci: release via the shared ferramenta workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,30 +5,13 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
-  release-please:
-    name: Release Please
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-    steps:
-      - uses: googleapis/release-please-action@v4
-        id: release
-        with:
-          release-type: rust
-
-  publish:
-    name: Publish to crates.io
-    runs-on: ubuntu-latest
-    needs: release-please
-    if: ${{ needs.release-please.outputs.release_created }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+  release:
+    uses: sebastian-software/ferramenta/.github/workflows/release-rust.yml@main
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    secrets: inherit


### PR DESCRIPTION
Replaces the inline release-please + cargo publish pipeline with the shared reusable workflow from [ferramenta](https://github.com/sebastian-software/ferramenta) (`release-rust.yml`). The existing `release-please-config.json` / `.release-please-manifest.json` keep working unchanged.

One semantic improvement: the shared workflow gates on `releases_created == 'true'` (string compare) instead of the truthy-string check, and reads the config explicitly.

Note: the stuck release PR #22 (1.3.0, open since March) is blocked by the red MSRV lane — see #34. Once CI is green and #22 merges, this workflow publishes 1.3.0 to crates.io as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)