### PR TITLE
fix: repair the MSRV lane and Release Please versioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
-      - name: Remove Cargo.lock for MSRV compatibility
-        if: matrix.rust != 'stable'
+      # The MSRV (1.81) lane keeps the committed Cargo.lock: fresh resolution
+      # pulls dependencies whose manifests cargo 1.81 cannot parse (e.g. clap
+      # 4.6 uses edition 2024), so only nightly tests an unpinned graph.
+      - name: Remove Cargo.lock for fresh resolution
+        if: matrix.rust == 'nightly'
         shell: bash
         run: rm -f Cargo.lock
       - name: Build

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,7 @@
       "release-type": "rust",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
-      "release-as": "1.0.0"
+      "include-component-in-tag": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
Fixes both halves of #34: the red MSRV lane on main and the release pipeline that has kept 1.3.0 from shipping since March.

## MSRV lane (CI)

The 1.81 matrix jobs deleted `Cargo.lock` and resolved fresh, so any upstream release with an `edition = "2024"` manifest (currently clap 4.6, pulled in via criterion) breaks all three jobs with `failed to parse manifest`. The MSRV lane now builds against the committed lockfile (clap is pinned at 4.5.58 there); only nightly still tests an unpinned dependency graph.

Verified locally with a real 1.81 toolchain and the committed lockfile: `cargo build`, `compat_syntax` (43), `compat_options` (48), `compat_regset` (15), and the full `compat_utf8` suite (1568) all pass. Clippy and rustfmt lanes are clean on stable.

## Release Please versioning

`release-please-config.json` still carried `"release-as": "1.0.0"` from the initial setup. The old workflow (`release-please-action` with `release-type: rust`, no manifest mode) never read this file, so 1.0.1–1.2.8 shipped fine. The shared ferramenta release workflow does read it, which is why PR #22 regressed to "release ferroni 1.0.0" — and because it also looked for component-prefixed tags (`ferroni-v*`) that don't exist, it rebuilt the changelog from the entire history.

This PR removes the stale `release-as` pin and sets `"include-component-in-tag": false` so Release Please finds the existing `v1.2.8` tag again. Commits since v1.2.8 contain `feat`s and no breaking changes, so the regenerated release PR should propose **1.3.0** with a changelog scoped to the commits since March.

After merging, Release Please will rewrite its release PR on the next push to main; merging that then finally ships 1.3.0 to crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_