### PR TITLE
fix: make the ffi feature survive crate packaging and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,18 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  ffi-smoke:
+    name: FFI feature smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Prepare Oniguruma sources
+        run: ./scripts/prepare-oniguruma-sources.sh
+      - name: Check ffi feature
+        run: cargo check --features ffi
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,17 @@ jobs:
         run: ./scripts/prepare-oniguruma-sources.sh
       - name: Check ffi feature
         run: cargo check --features ffi
+      # The original breakage only showed in the published layout (benches/
+      # and scripts/ are excluded from the crate), so also check the packaged
+      # artifact with the sources supplied via FERRONI_ONIGURUMA_DIR.
+      - name: Check ffi feature from the packaged crate
+        run: |
+          cargo package --no-verify
+          crate=$(ls target/package/ferroni-*.crate)
+          tar -xzf "$crate" -C target/package
+          pkg_dir="${crate%.crate}"
+          FERRONI_ONIGURUMA_DIR="$GITHUB_WORKSPACE/.cache/upstream/oniguruma-orig" \
+            cargo check --features ffi --manifest-path "$pkg_dir/Cargo.toml"
 
   clippy:
     name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ autobenches = false
 exclude = [".cache/", "benches/", "docs/", "scripts/"]
 
 [features]
+# Benchmark-comparison harness: links a local upstream Oniguruma checkout
+# (scripts/prepare-oniguruma-sources.sh or FERRONI_ONIGURUMA_DIR) for the
+# in-repo C-vs-Rust benches. Not needed to use the library.
 ffi = ["cc"]
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Oniguruma and vscode-oniguruma.
 Cross-compiles to `wasm32-unknown-unknown`. Easier to package in Rust-native
 stacks and downstream bindings, including N-API modules, without `node-gyp`
 or a local C compiler.
-Only enabling the optional `ffi` feature requires a local Oniguruma source
-snapshot for reference benchmarks. Rust also removes whole classes of C
+Only the optional `ffi` feature — the C-vs-Rust benchmark harness, not
+needed to use the library — requires a local Oniguruma source snapshot
+(`./scripts/prepare-oniguruma-sources.sh` or `FERRONI_ONIGURUMA_DIR`). Rust also removes whole classes of C
 memory bugs structurally; C Oniguruma has a long history of memory-safety
 CVEs, while Ferroni keeps `unsafe` at 0.4%, all documented in
 [ADR-002](https://sebastian-software.github.io/ferroni/adr/002-unsafe-code-policy).

--- a/build.rs
+++ b/build.rs
@@ -130,7 +130,13 @@ fn build_oniguruma_c() {
     }
 
     // Also compile the vscode-oniguruma scanner wrapper (for benchmarks).
-    build.file("benches/vscode_scanner_native.c");
+    // The file is excluded from the published crate (benches/ is not
+    // packaged), so skip it when building from crates.io — only the
+    // in-repo benchmarks link against it.
+    let bench_wrapper = std::path::Path::new("benches/vscode_scanner_native.c");
+    if bench_wrapper.exists() {
+        build.file(bench_wrapper);
+    }
 
     build.compile("oniguruma");
 }


### PR DESCRIPTION
Second audit batch for ferroni — repairs the one publicly advertised feature that could not work from crates.io.

## Problem

`cargo add ferroni --features ffi` failed for every crates.io consumer: `build.rs` unconditionally compiles `benches/vscode_scanner_native.c`, but `Cargo.toml`'s `exclude` strips `benches/` (and `scripts/`) from the published package, so the `cc` step died on a missing file — and the fallback panic pointed at a script that also is not in the tarball.

## Fix

- `build.rs` compiles the vscode-oniguruma scanner wrapper only when the file exists. It is linked exclusively by the in-repo benchmarks, so skipping it in the packaged context loses nothing; with `FERRONI_ONIGURUMA_DIR` set, the C-library link path now works from the published crate too.
- The `ffi` feature is documented for what it is — the C-vs-Rust benchmark-comparison harness, not needed to use the library — both in `Cargo.toml` and in the README (which now also names the two ways to provide sources).
- A new `ffi-smoke` CI job runs `./scripts/prepare-oniguruma-sources.sh` + `cargo check --features ffi`, so this path can no longer rot silently. This PR's own CI run is the first validation of that job (the sandboxed dev environment cannot fetch the pinned Oniguruma archive, so the job is the authoritative check).

Default build verified locally (`cargo check` clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_