### PR TITLE
docs: document every unsafe site and enforce the unsafe lints

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,8 +76,8 @@
 // Allow patterns inherent to the C port.
 #![allow(dead_code)]
 #![allow(clippy::empty_line_after_doc_comments)]
-#![allow(clippy::missing_transmute_annotations)]
-#![allow(clippy::not_unsafe_ptr_arg_deref)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![warn(clippy::undocumented_unsafe_blocks)]
 // Enable #[coverage(off)] attribute when running under cargo-llvm-cov on nightly.
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 

--- a/src/regcomp.rs
+++ b/src/regcomp.rs
@@ -481,6 +481,10 @@ fn tune_next(node: &mut Node, next_node: &Node, reg: &RegexType) -> i32 {
     let mut called = false;
 
     loop {
+        // SAFETY: `cur` starts as the exclusive `&mut node` argument and is only
+        // reassigned to the boxed body of the Memory bag it points to (below), so
+        // it always points to a live node inside the caller's exclusively borrowed
+        // tree, and no other reference to it exists while `n` is in use.
         let n = unsafe { &mut *cur };
         match &mut n.inner {
             NodeInner::Quant(ref mut qn) => {
@@ -3250,6 +3254,12 @@ fn node_min_byte_len(node: &Node, env: &ParseEnv) -> OnigLen {
                         0 // recursive cycle
                     } else {
                         // Set MARK1 for cycle detection, compute, cache with FIXED_MIN
+                        // SAFETY: this analysis runs single-threaded while onig_compile
+                        // holds the tree exclusively; `node` derives from that exclusive
+                        // borrow, so no other live reference observes the writes. Only
+                        // the `status` flags and the `min_len` cache are mutated, and
+                        // the MARK1 flag set here prevents re-entering this node
+                        // through a recursive call cycle.
                         unsafe {
                             let node_ptr = node as *const Node as *mut Node;
                             (*node_ptr).status_add(ND_ST_MARK1);
@@ -3309,6 +3319,10 @@ fn node_min_byte_len(node: &Node, env: &ParseEnv) -> OnigLen {
 
         NodeInner::Call(ref cn) => {
             if !cn.target_node.is_null() {
+                // SAFETY: `target_node` is non-null (checked above) and was set by
+                // resolve_call_references/refresh_call_targets to the called group's
+                // Bag node inside this same tree, which stays alive and unmoved for
+                // the duration of the analysis.
                 unsafe { node_min_byte_len(&*cn.target_node, env) }
             } else {
                 0
@@ -3747,6 +3761,9 @@ fn node_char_len(node: &Node, enc: OnigEncoding) -> CharLenResult {
         NodeInner::Call(ref cn) => {
             // Follow the call target to compute the character length of the called group
             if !cn.target_node.is_null() {
+                // SAFETY: `target_node` is non-null (checked above) and was set by
+                // resolve_call_references/refresh_call_targets to the called group's
+                // Bag node inside this same live tree; only shared reads follow.
                 let target = unsafe { &*cn.target_node };
                 node_char_len(target, enc)
             } else {
@@ -4052,6 +4069,9 @@ fn check_node_in_look_behind(node: &Node, not: bool, used: &mut bool) -> i32 {
                 *used = true;
                 0
             } else if !cn.target_node.is_null() {
+                // SAFETY: `target_node` is non-null (checked above) and was set by
+                // resolve_call_references/refresh_call_targets to the called group's
+                // Bag node inside this same live tree; only shared reads follow.
                 let target = unsafe { &*cn.target_node };
                 check_called_node_in_look_behind(target, not)
             } else {
@@ -4102,6 +4122,9 @@ fn list_reduce_in_look_behind(node: &mut Node) {
             // Walk the list, reducing each car
             let mut cur = node as *mut Node;
             loop {
+                // SAFETY: `cur` starts as the exclusive `&mut node` argument and is
+                // only advanced to the boxed cdr of the cons it points to, so it
+                // always points to a live node in the exclusively borrowed chain.
                 unsafe {
                     if let NodeInner::List(ref mut cons) = (*cur).inner {
                         let removed = node_reduce_in_look_behind(&mut cons.car);
@@ -4131,6 +4154,9 @@ fn alt_reduce_in_look_behind(node: &mut Node) {
         NodeInner::Alt(_) => {
             let mut cur = node as *mut Node;
             loop {
+                // SAFETY: `cur` starts as the exclusive `&mut node` argument and is
+                // only advanced to the boxed cdr of the cons it points to, so it
+                // always points to a live node in the exclusively borrowed chain.
                 unsafe {
                     if let NodeInner::Alt(ref mut cons) = (*cur).inner {
                         list_reduce_in_look_behind(&mut cons.car);
@@ -4184,6 +4210,9 @@ fn strip_redundant_casefold_alts_in_lookbehind(node: &mut Node, enc: OnigEncodin
 
     // Walk the cdr chain and check each string alternative
     let all_covered = {
+        // SAFETY: `cc_ptr` was taken just above from the CClass in the first Alt
+        // branch of `body`; the walk below only reads the chain and never mutates
+        // `body`, so the pointee stays live while `cc` is in use.
         let cc = unsafe { &*cc_ptr };
         let mut cur: &Node = body;
         let mut has_alts = false;
@@ -4406,6 +4435,12 @@ fn resolve_call_references(node: &mut Node, reg: &mut RegexType, env: &mut Parse
                 // Mark the target group as CALLED
                 mem_node_ptr = env.mem_env(gnum as usize).mem_node;
                 if !mem_node_ptr.is_null() {
+                    // SAFETY: `mem_node_ptr` is non-null (checked above) and was
+                    // recorded by the parser as group `gnum`'s Bag node in the tree
+                    // currently being resolved, so it is live. Only a `status` bit is
+                    // set; suspended traversal frames that borrow this node (when the
+                    // target encloses this call) do not read `status` until after
+                    // this write completes.
                     unsafe {
                         (*mem_node_ptr).status_add(ND_ST_CALLED);
                     }
@@ -4421,6 +4456,12 @@ fn resolve_call_references(node: &mut Node, reg: &mut RegexType, env: &mut Parse
                         call.called_gnum = nums[0];
                         mem_node_ptr = env.mem_env(nums[0] as usize).mem_node;
                         if !mem_node_ptr.is_null() {
+                            // SAFETY: `mem_node_ptr` is non-null (checked above) and
+                            // was recorded by the parser as the named group's Bag node
+                            // in the tree currently being resolved, so it is live.
+                            // Only a `status` bit is set; suspended traversal frames
+                            // that borrow this node (when the target encloses this
+                            // call) do not read `status` until after this write.
                             unsafe {
                                 (*mem_node_ptr).status_add(ND_ST_CALLED);
                             }
@@ -4511,6 +4552,12 @@ fn recursive_call_check_inner(node: &mut Node) -> i32 {
         NodeType::List | NodeType::Alt => {
             let mut r = 0;
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node. `car`
+            // and `cdr` are disjoint fields of the cons, so recursing into car
+            // while keeping the cdr pointer creates no overlapping &mut; re-entry
+            // into this chain via call targets is cut off by the MARK1/MARK2
+            // guards on Bag Memory nodes.
             unsafe {
                 while let NodeInner::List(cons) | NodeInner::Alt(cons) = &mut (*cur).inner {
                     let car = &mut cons.car as *mut Box<Node>;
@@ -4549,6 +4596,11 @@ fn recursive_call_check_inner(node: &mut Node) -> i32 {
         }
         NodeType::Call => {
             // Follow the call target via raw pointer
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; `target`
+            // (when non-null) points to the called group's Bag node in this same
+            // tree, set by resolve_call_references. The MARK1/MARK2 guards in the
+            // Bag Memory arm stop the recursion before any node is entered twice
+            // on one path, so no overlapping &mut is created.
             unsafe {
                 if let NodeInner::Call(ref cn) = (*node_ptr).inner {
                     let target = cn.target_node;
@@ -4575,6 +4627,11 @@ fn recursive_call_check_inner(node: &mut Node) -> i32 {
 
             if is_memory {
                 // Use raw pointer to check/set status while inner is borrowed
+                // SAFETY: `node_ptr` is the exclusive `&mut node` argument, so it is
+                // valid and live; the raw pointer only lets the `status` flags be
+                // toggled around the borrow of `inner` (disjoint fields). The MARK2
+                // flag set here makes any re-entry through a call cycle return at
+                // the guards above before the body is borrowed a second time.
                 unsafe {
                     if (*node_ptr).has_status(ND_ST_MARK2) {
                         return 0;
@@ -4595,6 +4652,8 @@ fn recursive_call_check_inner(node: &mut Node) -> i32 {
                     r
                 }
             } else {
+                // SAFETY: `node_ptr` is the exclusive `&mut node` argument; this is
+                // a plain reborrow used to recurse into the bag's children.
                 unsafe {
                     if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
                         if let BagData::IfElse {
@@ -4643,6 +4702,10 @@ fn recursive_call_check_trav(node: &mut Node, env: &mut ParseEnv, state: i32) ->
         NodeType::List | NodeType::Alt => {
             let mut r = 0;
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node. `car`
+            // and `cdr` are disjoint fields of the cons, so recursing into car
+            // while keeping the cdr pointer creates no overlapping &mut.
             unsafe {
                 while let NodeInner::List(cons) | NodeInner::Alt(cons) = &mut (*cur).inner {
                     let car = &mut cons.car as *mut Box<Node>;
@@ -4660,6 +4723,8 @@ fn recursive_call_check_trav(node: &mut Node, env: &mut ParseEnv, state: i32) ->
             }
             r
         }
+        // SAFETY: `node_ptr` is the exclusive `&mut node` argument; the two
+        // sequential borrows of `inner` through it never overlap.
         NodeType::Quant => unsafe {
             let upper = if let NodeInner::Quant(ref qn) = (*node_ptr).inner {
                 qn.upper
@@ -4693,6 +4758,8 @@ fn recursive_call_check_trav(node: &mut Node, env: &mut ParseEnv, state: i32) ->
         }
         NodeType::Bag => {
             // Extract info before borrowing inner mutably
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; only shared
+            // reads of `inner` and `status` are performed here.
             let (is_memory, is_if_else, is_called, regnum) = unsafe {
                 if let NodeInner::Bag(ref bn) = (*node_ptr).inner {
                     let is_mem = bn.bag_type == BagType::Memory;
@@ -4714,6 +4781,10 @@ fn recursive_call_check_trav(node: &mut Node, env: &mut ParseEnv, state: i32) ->
                     r = FOUND_CALLED_NODE;
                 }
                 if is_called || (state & IN_RECURSION) != 0 {
+                    // SAFETY: `node_ptr` is the exclusive `&mut node` argument. The
+                    // MARK1 bit set here makes recursive_call_check_inner return at
+                    // its guard if a call cycle leads back to this node, so its body
+                    // is never mutably entered twice.
                     unsafe {
                         if !(*node_ptr).has_status(ND_ST_RECURSION) {
                             (*node_ptr).status_add(ND_ST_MARK1);
@@ -4733,12 +4804,16 @@ fn recursive_call_check_trav(node: &mut Node, env: &mut ParseEnv, state: i32) ->
             }
 
             let mut state1 = state;
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; shared read
+            // of the `status` flags only.
             unsafe {
                 if (*node_ptr).has_status(ND_ST_RECURSION) {
                     state1 |= IN_RECURSION;
                 }
             }
 
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; plain
+            // reborrow used to recurse into the bag's children.
             unsafe {
                 if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
                     if let Some(ref mut body) = bn.body {
@@ -4794,6 +4869,11 @@ fn make_named_capture_number_map(
     match node_type {
         NodeType::List | NodeType::Alt => {
             let cur = node as *mut Node;
+            // SAFETY: `p` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node; `car`
+            // and `cdr` are disjoint fields, so recursing into car while holding
+            // the cdr pointer creates no overlapping &mut (this pass follows no
+            // call targets).
             unsafe {
                 let mut p = cur;
                 while let NodeInner::List(ref mut cons) | NodeInner::Alt(ref mut cons) = (*p).inner
@@ -4819,6 +4899,9 @@ fn make_named_capture_number_map(
                 None
             };
             if let Some(bp) = body_ptr {
+                // SAFETY: `bp` points to the quantifier's boxed body, extracted above
+                // to end the borrow of `node.inner`; no other reference to the body
+                // exists during the call.
                 let r = unsafe { make_named_capture_number_map(&mut *bp, map, counter) };
                 if r < 0 {
                     return r;
@@ -4875,6 +4958,8 @@ fn make_named_capture_number_map(
             }
 
             // IfElse or other bag types
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; plain
+            // reborrow used to recurse into the bag's children.
             unsafe {
                 let node_ptr = node as *mut Node;
                 if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
@@ -4965,6 +5050,11 @@ fn renumber_backref_traverse(node: &mut Node, map: &[GroupNumMap]) -> i32 {
     match node.node_type() {
         NodeType::List | NodeType::Alt => {
             let cur = node as *mut Node;
+            // SAFETY: `p` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node; `car`
+            // and `cdr` are disjoint fields, so recursing into car while holding
+            // the cdr pointer creates no overlapping &mut (this pass follows no
+            // call targets).
             unsafe {
                 let mut p = cur;
                 while let NodeInner::List(ref mut cons) | NodeInner::Alt(ref mut cons) =
@@ -4995,6 +5085,8 @@ fn renumber_backref_traverse(node: &mut Node, map: &[GroupNumMap]) -> i32 {
             0
         }
         NodeType::Bag => {
+            // SAFETY: `node_ptr` is the exclusive `&mut node` argument; plain
+            // reborrow used to recurse into the bag's children.
             unsafe {
                 let node_ptr = node as *mut Node;
                 if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
@@ -5193,6 +5285,10 @@ fn infinite_recursive_call_check(node: &mut Node, env: &ParseEnv, head: i32) -> 
         NodeType::List => {
             let mut head = head;
             let cur = node as *mut Node;
+            // SAFETY: `p` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node. Cycles
+            // through call targets are cut by the MARK1/MARK2 guards on Bag
+            // Memory nodes before this chain could be re-entered.
             unsafe {
                 let mut p = cur;
                 while let NodeInner::List(ref mut cons) = &mut (*p).inner {
@@ -5217,6 +5313,10 @@ fn infinite_recursive_call_check(node: &mut Node, env: &ParseEnv, head: i32) -> 
         NodeType::Alt => {
             let mut must = RECURSION_MUST;
             let cur = node as *mut Node;
+            // SAFETY: `p` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node. Cycles
+            // through call targets are cut by the MARK1/MARK2 guards on Bag
+            // Memory nodes before this chain could be re-entered.
             unsafe {
                 let mut p = cur;
                 while let NodeInner::Alt(ref mut cons) = &mut (*p).inner {
@@ -5261,6 +5361,11 @@ fn infinite_recursive_call_check(node: &mut Node, env: &ParseEnv, head: i32) -> 
             // Follow call to its target (the BAG_MEMORY node it references)
             if let NodeInner::Call(ref cn) = node.inner {
                 if !cn.target_node.is_null() {
+                    // SAFETY: `target_node` is non-null (checked above) and points to
+                    // the called group's Bag Memory node in this same live tree. A
+                    // target already being visited has MARK1 or MARK2 set and returns
+                    // at the guards before touching its body, so no overlapping &mut
+                    // to a node's children is created.
                     r = unsafe { infinite_recursive_call_check(&mut *cn.target_node, env, head) };
                 }
             }
@@ -5293,6 +5398,8 @@ fn infinite_recursive_call_check(node: &mut Node, env: &ParseEnv, head: i32) -> 
                     }
                 }
                 BagType::IfElse => {
+                    // SAFETY: `node_ptr` is the exclusive `&mut node` argument; plain
+                    // reborrow used to recurse into the bag's children.
                     unsafe {
                         let node_ptr = node as *mut Node;
                         if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
@@ -5367,6 +5474,9 @@ fn infinite_recursive_call_check_trav(node: &mut Node, env: &ParseEnv) -> i32 {
     match node.node_type() {
         NodeType::List | NodeType::Alt => {
             let cur = node as *mut Node;
+            // SAFETY: `p` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr, so every deref is of a live node; the
+            // recursion into car borrows a field disjoint from the cdr link.
             unsafe {
                 let mut p = cur;
                 while let NodeInner::List(cons) | NodeInner::Alt(cons) = &mut (*p).inner {
@@ -5427,6 +5537,8 @@ fn infinite_recursive_call_check_trav(node: &mut Node, env: &ParseEnv) -> i32 {
                 node.status_remove(ND_ST_MARK1);
             }
             if bag_type == BagType::IfElse {
+                // SAFETY: `node_ptr` is the exclusive `&mut node` argument; plain
+                // reborrow used to recurse into the if-else branches.
                 unsafe {
                     let node_ptr = node as *mut Node;
                     if let NodeInner::Bag(ref mut bn) = (*node_ptr).inner {
@@ -5474,6 +5586,10 @@ fn infinite_recursive_call_check_trav(node: &mut Node, env: &ParseEnv) -> i32 {
 /// Call reference resolution is already handled by resolve_call_references.
 fn tune_call(node: &mut Node, state: i32) {
     let np = node as *mut Node;
+    // SAFETY: `np` is the exclusive `&mut node` argument; all derefs are
+    // reborrows of it or of boxed cdr nodes reached from it, and the raw
+    // pointer only serves to update `status` around borrows of `inner`
+    // (disjoint fields). This pass follows no call targets.
     unsafe {
         match &mut (*np).inner {
             NodeInner::List(_) | NodeInner::Alt(_) => {
@@ -5555,6 +5671,11 @@ fn tune_call(node: &mut Node, state: i32) {
 /// C: tune_call2_call — traverse from a Call node to count entries on called targets.
 fn tune_call2_call(node: &mut Node) {
     let np = node as *mut Node;
+    // SAFETY: `np` is the exclusive `&mut node` argument; derefs are reborrows
+    // of it or of boxed cdr nodes. The Call arm also follows `target_node`,
+    // which points to the called group's Bag node in this same live tree; the
+    // MARK1 guards on both Call and Memory nodes stop call cycles before any
+    // node is mutably entered twice on one path.
     unsafe {
         match &mut (*np).inner {
             NodeInner::List(_) | NodeInner::Alt(_) => {
@@ -5638,6 +5759,9 @@ fn tune_call2_call(node: &mut Node) {
 /// C: tune_call2 — traverse tree, for each non-zero-repeat Call, invoke tune_call2_call.
 fn tune_call2(node: &mut Node) -> i32 {
     let np = node as *mut Node;
+    // SAFETY: `np` is the exclusive `&mut node` argument; all derefs are
+    // reborrows of it or of boxed cdr nodes reached from it. Call targets are
+    // only entered via tune_call2_call, which guards cycles with MARK1.
     unsafe {
         match &mut (*np).inner {
             NodeInner::List(_) | NodeInner::Alt(_) => {
@@ -5711,6 +5835,10 @@ fn tune_call2(node: &mut Node) -> i32 {
 #[cfg_attr(coverage_nightly, coverage(off))]
 fn tune_called_state_call(node: &mut Node, state: i32) {
     let np = node as *mut Node;
+    // SAFETY: `np` is the exclusive `&mut node` argument; derefs are reborrows
+    // of it or of boxed cdr nodes, and the raw pointer only updates `status`
+    // around borrows of `inner` (disjoint fields). Re-entry through call
+    // cycles is cut by the MARK1 guard on Bag Memory nodes.
     unsafe {
         match &mut (*np).inner {
             NodeInner::Alt(_) => {
@@ -5836,6 +5964,10 @@ fn tune_called_state_call(node: &mut Node, state: i32) {
 /// C: tune_called_state — propagate state flags down the tree, entering called groups.
 fn tune_called_state(node: &mut Node, state: i32) {
     let np = node as *mut Node;
+    // SAFETY: `np` is the exclusive `&mut node` argument; all derefs are
+    // reborrows of it or of boxed cdr nodes reached from it. Called groups are
+    // entered only through tune_called_state_call, which guards call cycles
+    // with MARK1.
     unsafe {
         match &mut (*np).inner {
             NodeInner::Alt(_) => {
@@ -6001,6 +6133,10 @@ fn recurse_into_children(
     match &mut node.inner {
         NodeInner::List(_) | NodeInner::Alt(_) => {
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to the boxed cdr; `car` and `cdr` are disjoint fields, so
+            // recursing into car (which may rewrite that subtree in place) never
+            // aliases the cdr chain still being walked.
             unsafe {
                 while let NodeInner::List(ref mut cons) | NodeInner::Alt(ref mut cons) =
                     (*cur).inner
@@ -6049,6 +6185,9 @@ fn try_trie_optimize_alt(
     {
         let mut cur: *const Node = node;
         let mut idx = 0usize;
+        // SAFETY: `cur` starts as the exclusive `&mut node` argument (demoted to
+        // shared) and only advances to boxed cdr nodes, so every deref is of a
+        // live node; this walk and classify_branch perform reads only.
         unsafe {
             loop {
                 let (car, cdr) = match &(*cur).inner {
@@ -6197,6 +6336,10 @@ fn extract_literal_paths(
     if current_prefixes.len() > limit {
         return None;
     }
+    // SAFETY: callers pass `node` pointing at a live node of the tree currently
+    // borrowed by try_trie_optimize_alt (classify_branch derives it from a
+    // reference; recursive calls pass children of the dereferenced node), and
+    // only shared reads are performed.
     unsafe {
         match &(*node).inner {
             NodeInner::String(ref sn) => {
@@ -6365,6 +6508,9 @@ fn classify_branch(node: *const Node, backrefed_mem: MemStatusType) -> AltBranch
 
 /// Check if a node is a plain literal string (non-crude, no ND_ST_LITERAL_ALT).
 fn check_literal_branch(node: *const Node) -> (bool, Vec<u8>) {
+    // SAFETY: callers pass `node` pointing at a live node of the currently
+    // borrowed tree (derived from references in try_trie_optimize_alt and
+    // classify_branch); only shared reads are performed.
     unsafe {
         if (*node).has_status(ND_ST_LITERAL_ALT) {
             return (false, Vec::new());
@@ -6384,6 +6530,10 @@ fn extract_alt_branches(alt_node: &mut Node, indices: &[usize], out: &mut Vec<No
     // Walk the Alt cons-chain and collect the nodes at the given indices.
     let mut idx = 0usize;
     let mut cur: *mut Node = alt_node;
+    // SAFETY: `cur` starts as the exclusive `&mut alt_node` argument and only
+    // advances to boxed cdr nodes, so every deref is of a live, exclusively
+    // borrowed node; the mem::replace calls swap out whole cars (or the tail
+    // node) without touching the chain links still to be walked.
     unsafe {
         loop {
             match &mut (*cur).inner {
@@ -6456,6 +6606,12 @@ pub fn tune_tree(node: &mut Node, reg: &mut RegexType, state: i32, env: &mut Par
             // Walk the list: tune each element, then call tune_next for sequential pairs
             let mut cur: *mut Node = node;
             let mut prev: *mut Node = std::ptr::null_mut();
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to boxed cdr nodes. `prev` points at the previous
+            // element's car — a node distinct from the current `cons.car` — so
+            // the `&mut *prev` passed to tune_next does not alias the `&cons.car`
+            // passed alongside it; tune_tree rewrites cars in place and never
+            // moves or frees their boxed allocations.
             unsafe {
                 while let NodeInner::List(ref mut cons) = (*cur).inner {
                     let r = tune_tree(&mut cons.car, reg, state, env);
@@ -6481,6 +6637,9 @@ pub fn tune_tree(node: &mut Node, reg: &mut RegexType, state: i32, env: &mut Par
 
         NodeInner::Alt(_) => {
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to boxed cdr nodes, so every deref is of a live,
+            // exclusively borrowed node.
             unsafe {
                 while let NodeInner::Alt(ref mut cons) = (*cur).inner {
                     let r = tune_tree(&mut cons.car, reg, state | IN_ALT, env);
@@ -6744,6 +6903,10 @@ fn mark_empty_repeat_node(node: &mut Node, env: &mut ParseEnv) {
         }
         NodeInner::List(_) | NodeInner::Alt(_) => {
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to boxed cdr nodes, so every deref is of a live,
+            // exclusively borrowed node; the recursion into car borrows a field
+            // disjoint from the cdr link.
             unsafe {
                 while let NodeInner::List(ref mut cons) | NodeInner::Alt(ref mut cons) =
                     (*cur).inner
@@ -6868,6 +7031,12 @@ fn resolve_empty_status_backrefs(
                     // Check if the backref is inside the quantifier
                     if !enclosing_quants.contains(&(er_node as *const Node)) {
                         // Backref is OUTSIDE the quantifier → set empty_status_mem
+                        // SAFETY: `er_node` was set by mark_empty_repeat_node (pass 1)
+                        // to a Quant node in this same tree, which has not been
+                        // restructured since, so it is live. Every empty quantifier
+                        // on the current traversal path is in `enclosing_quants`, so
+                        // the contains() check above guarantees `er_node` is not a
+                        // node this traversal currently borrows.
                         unsafe {
                             if let NodeInner::Quant(ref mut qn) = (*er_node).inner {
                                 qn.empty_status_mem |= 1u32 << back;
@@ -6880,6 +7049,10 @@ fn resolve_empty_status_backrefs(
         }
         NodeInner::List(_) | NodeInner::Alt(_) => {
             let mut cur: *mut Node = node;
+            // SAFETY: `cur` starts as the exclusive `&mut node` argument and only
+            // advances to boxed cdr nodes, so every deref is of a live,
+            // exclusively borrowed node; the recursion into car borrows a field
+            // disjoint from the cdr link.
             unsafe {
                 while let NodeInner::List(ref mut cons) | NodeInner::Alt(ref mut cons) =
                     (*cur).inner
@@ -7758,6 +7931,10 @@ fn node_max_byte_len(node: &Node, env: &ParseEnv) -> OnigLen {
                 for &back in br.back_refs() {
                     let me = env.mem_env(back as usize);
                     if !me.mem_node.is_null() {
+                        // SAFETY: `mem_node` is non-null (checked above) and was set
+                        // by refresh_capture_nodes to the referenced group's Bag node
+                        // in this same tree, which stays alive and unmoved
+                        // throughout this analysis pass.
                         let mem_node = unsafe { &*me.mem_node };
                         let tmax = node_max_byte_len(mem_node, env);
                         if len < tmax {
@@ -7772,6 +7949,10 @@ fn node_max_byte_len(node: &Node, env: &ParseEnv) -> OnigLen {
             if node.has_status(ND_ST_RECURSION) {
                 INFINITE_LEN
             } else if !cn.target_node.is_null() {
+                // SAFETY: `target_node` is non-null (checked above) and was set by
+                // resolve_call_references/refresh_call_targets to the called group's
+                // Bag node inside this same tree, which stays alive and unmoved for
+                // the duration of the analysis.
                 unsafe { node_max_byte_len(&*cn.target_node, env) }
             } else {
                 0
@@ -7802,6 +7983,12 @@ fn node_max_byte_len(node: &Node, env: &ParseEnv) -> OnigLen {
                 } else if node.has_status(ND_ST_MARK1) {
                     INFINITE_LEN
                 } else {
+                    // SAFETY: this analysis runs single-threaded while onig_compile
+                    // holds the tree exclusively; `node` derives from that exclusive
+                    // borrow, so no other live reference observes the writes. Only
+                    // the `status` flags and the `max_len` cache are mutated, and
+                    // the MARK1 flag set here prevents re-entering this node through
+                    // a recursive call cycle.
                     unsafe {
                         let node_ptr = node as *const Node as *mut Node;
                         (*node_ptr).status_add(ND_ST_MARK1);
@@ -8043,6 +8230,10 @@ fn optimize_nodes(
             if node.has_status(ND_ST_RECURSION) {
                 opt.len.set(0, INFINITE_LEN);
             } else if !cn.target_node.is_null() {
+                // SAFETY: `target_node` is non-null (checked above) and was set by
+                // resolve_call_references/refresh_call_targets to the called group's
+                // Bag node inside this same live tree; recursion through the target
+                // is bounded by the `opt_count` counter in the Memory arm below.
                 let target = unsafe { &*cn.target_node };
                 let r = optimize_nodes(target, opt, enc, env_mm, scan_env);
                 if r != 0 {
@@ -8114,6 +8305,10 @@ fn optimize_nodes(
                 }
             }
             BagType::Memory => {
+                // SAFETY: the optimize pass runs single-threaded on a tree that
+                // onig_compile holds exclusively (demoted to shared references for
+                // this traversal), so no other reference observes the write; only
+                // the `opt_count` recursion-bound counter is mutated.
                 let opt_count = unsafe {
                     let bn_ptr = bn as *const BagNode as *mut BagNode;
                     (*bn_ptr).opt_count += 1;
@@ -8378,6 +8573,10 @@ pub fn onig_compile(reg: &mut RegexType, pattern: &[u8]) -> i32 {
         options: reg.options,
         case_fold_flag: reg.case_fold_flag,
         enc: reg.enc,
+        // SAFETY: `reg.syntax` is set by the safe constructors (api.rs) from a
+        // `&'static OnigSyntaxType`; FFI entry points require the caller to pass
+        // a valid syntax that outlives the regex. Either way the pointee is
+        // live, aligned, and not mutated for the whole compile.
         syntax: unsafe { &*reg.syntax },
         cap_history: 0,
         backtrack_mem: 0,

--- a/src/regexec.rs
+++ b/src/regexec.rs
@@ -90,7 +90,10 @@ pub fn onig_get_progress_callout() -> Option<OnigCalloutFunc> {
     if p.is_null() {
         None
     } else {
-        Some(unsafe { std::mem::transmute(p) })
+        // SAFETY: a non-null pointer in this static was stored by
+        // onig_set_progress_callout, which cast an OnigCalloutFunc to
+        // *mut (), so the round-trip restores the original fn pointer.
+        Some(unsafe { std::mem::transmute::<*mut (), OnigCalloutFunc>(p) })
     }
 }
 
@@ -109,7 +112,10 @@ pub fn onig_get_retraction_callout() -> Option<OnigCalloutFunc> {
     if p.is_null() {
         None
     } else {
-        Some(unsafe { std::mem::transmute(p) })
+        // SAFETY: a non-null pointer in this static was stored by
+        // onig_set_retraction_callout, which cast an OnigCalloutFunc to
+        // *mut (), so the round-trip restores the original fn pointer.
+        Some(unsafe { std::mem::transmute::<*mut (), OnigCalloutFunc>(p) })
     }
 }
 
@@ -136,7 +142,11 @@ pub fn onig_get_callback_each_match() -> Option<OnigCallbackEachMatchFunc> {
     if p.is_null() {
         None
     } else {
-        Some(unsafe { std::mem::transmute(p) })
+        // SAFETY: a non-null pointer in this static was stored by
+        // onig_set_callback_each_match, which cast an
+        // OnigCallbackEachMatchFunc to *mut (), so the round-trip restores
+        // the original fn pointer.
+        Some(unsafe { std::mem::transmute::<*mut (), OnigCallbackEachMatchFunc>(p) })
     }
 }
 
@@ -203,6 +213,10 @@ pub fn onig_get_case_fold_flag(reg: &RegexType) -> OnigCaseFoldType {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_get_syntax(reg: &RegexType) -> &OnigSyntaxType {
+    // SAFETY: reg.syntax was set by onig_new (regcomp.rs) from the
+    // `&OnigSyntaxType` supplied at compile time -- in practice one of the
+    // `static OnigSyntax*` definitions in regsyntax.rs. The API requires
+    // that syntax to outlive the regex, so the pointer is valid and aligned.
     unsafe { &*reg.syntax }
 }
 
@@ -305,6 +319,10 @@ pub fn onig_noname_group_capture_is_active(reg: &RegexType) -> bool {
         return false;
     }
     if onig_number_of_names(reg) > 0 {
+        // SAFETY: reg.syntax was set by onig_new from the `&OnigSyntaxType`
+        // supplied at compile time (in practice a `static` from
+        // regsyntax.rs), which the API requires to outlive the regex, so the
+        // pointer is valid and aligned.
         let syntax = unsafe { &*reg.syntax };
         if is_syntax_bv(syntax, ONIG_SYN_CAPTURE_ONLY_NAMED_GROUP)
             && !opton_capture_group(reg.options)
@@ -571,9 +589,21 @@ impl OnigCalloutArgs {
             num,
             regex: reg as *const RegexType,
             string: str_data.as_ptr(),
+            // SAFETY: the match engine passes `end` as the subject length in
+            // bytes (end <= str_data.len()), so the offset stays inside or
+            // one past the end of the `str_data` allocation.
             string_end: unsafe { str_data.as_ptr().add(end) },
+            // SAFETY: the match engine passes `start` as a byte offset into
+            // the subject (start <= str_data.len()), so the offset stays
+            // inside or one past the end of the `str_data` allocation.
             start: unsafe { str_data.as_ptr().add(start) },
+            // SAFETY: the match engine passes `right_range` as a byte offset
+            // into the subject (right_range <= str_data.len()), so the offset
+            // stays inside or one past the end of the `str_data` allocation.
             right_range: unsafe { str_data.as_ptr().add(right_range) },
+            // SAFETY: the match engine passes `current` as a byte offset into
+            // the subject (current <= str_data.len()), so the offset stays
+            // inside or one past the end of the `str_data` allocation.
             current: unsafe { str_data.as_ptr().add(current) },
             retry_in_match_counter: retry_counter,
             str_data: str_data.as_ptr(),
@@ -610,6 +640,9 @@ pub fn onig_get_contents_by_callout_args(_args: &OnigCalloutArgs) -> Option<&[u8
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_get_args_num_by_callout_args(args: &OnigCalloutArgs) -> i32 {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if let Some(ref ext) = reg.extp {
         let idx = (args.num - 1) as usize;
@@ -622,6 +655,9 @@ pub fn onig_get_args_num_by_callout_args(args: &OnigCalloutArgs) -> i32 {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_get_passed_args_num_by_callout_args(args: &OnigCalloutArgs) -> i32 {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if let Some(ref ext) = reg.extp {
         let idx = (args.num - 1) as usize;
@@ -634,6 +670,9 @@ pub fn onig_get_passed_args_num_by_callout_args(args: &OnigCalloutArgs) -> i32 {
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_get_arg_by_callout_args(args: &OnigCalloutArgs, index: i32) -> Option<&CalloutArg> {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if let Some(ref ext) = reg.extp {
         let idx = (args.num - 1) as usize;
@@ -687,6 +726,9 @@ pub fn onig_get_retry_counter_by_callout_args(args: &OnigCalloutArgs) -> u64 {
 /// Returns null for name callouts.
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_get_contents_end_by_callout_args(args: &OnigCalloutArgs) -> *const u8 {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if let Some(ref ext) = reg.extp {
         let idx = (args.num - 1) as usize;
@@ -820,10 +862,17 @@ pub fn onig_get_callout_data_by_callout_args(
     callout_num: i32,
     slot: i32,
 ) -> Option<i64> {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if args.callout_data.is_null() {
         return None;
     }
+    // SAFETY: non-null was checked above. Whoever stores a non-null
+    // callout_data must point it at the match engine's live callout-data
+    // vector and hold no mutable reference to it while the callout runs, so
+    // the shared borrow is sound for the duration of this call.
     let cd = unsafe { &*args.callout_data };
     onig_get_callout_data(reg, cd, callout_num, slot)
 }
@@ -838,6 +887,10 @@ pub fn onig_set_callout_data_by_callout_args(
     if args.callout_data.is_null() {
         return ONIGERR_INVALID_ARGUMENT;
     }
+    // SAFETY: non-null was checked above. Whoever stores a non-null
+    // callout_data must point it at the match engine's live callout-data
+    // vector and hold no other reference to it while the callout runs, so
+    // the unique borrow is sound for the duration of this call.
     let cd = unsafe { &mut *args.callout_data };
     onig_set_callout_data(cd, callout_num, slot, val)
 }
@@ -974,6 +1027,9 @@ pub fn onig_builtin_mismatch(_args: &OnigCalloutArgs, _user_data: *mut std::ffi:
 
 #[cfg_attr(coverage_nightly, coverage(off))]
 pub fn onig_builtin_error(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_void) -> i32 {
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     if let Some(ref ext) = reg.extp {
         let idx = (args.num - 1) as usize;
@@ -998,6 +1054,10 @@ pub fn onig_builtin_count(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_v
     if args.callout_data.is_null() {
         return ONIG_CALLOUT_FAIL;
     }
+    // SAFETY: non-null was checked above. Whoever stores a non-null
+    // callout_data must point it at the match engine's live callout-data
+    // vector and hold no other reference to it while the callout runs, so
+    // the unique borrow is sound for the duration of this call.
     let cd = unsafe { &mut *args.callout_data };
     let num = args.num;
     if num < 1 {
@@ -1008,6 +1068,9 @@ pub fn onig_builtin_count(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_v
         return ONIG_CALLOUT_FAIL;
     }
 
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     let count_type = if let Some(ref ext) = reg.extp {
         if idx < ext.callout_list.len() && !ext.callout_list[idx].args.is_empty() {
@@ -1054,6 +1117,10 @@ pub fn onig_builtin_max(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_voi
     if args.callout_data.is_null() {
         return ONIG_CALLOUT_FAIL;
     }
+    // SAFETY: non-null was checked above. Whoever stores a non-null
+    // callout_data must point it at the match engine's live callout-data
+    // vector and hold no other reference to it while the callout runs, so
+    // the unique borrow is sound for the duration of this call.
     let cd = unsafe { &mut *args.callout_data };
     let num = args.num;
     if num < 1 {
@@ -1064,6 +1131,9 @@ pub fn onig_builtin_max(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_voi
         return ONIG_CALLOUT_FAIL;
     }
 
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     let ext = match reg.extp.as_ref() {
         Some(e) => e,
@@ -1125,10 +1195,19 @@ pub fn onig_builtin_skip(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_vo
     let current = if args.str_data.is_null() {
         0
     } else {
+        // SAFETY: `current` was computed in OnigCalloutArgs::new as
+        // `str_data.as_ptr().add(current)` from the same base pointer that
+        // was stored in `str_data`, so both pointers lie within the same
+        // allocation and current >= str_data; the offset is therefore valid
+        // and non-negative.
         unsafe { args.current.offset_from(args.str_data) as usize }
     };
 
     if !args.msa.is_null() {
+        // SAFETY: non-null was checked above. Whoever stores a non-null msa
+        // must point it at the MatchArg of the match in progress, kept alive
+        // and otherwise unreferenced by the match engine while the callout
+        // runs, so the unique borrow is sound for the duration of this call.
         let msa = unsafe { &mut *args.msa };
         if current > msa.skip_search {
             msa.skip_search = current;
@@ -1143,6 +1222,10 @@ pub fn onig_builtin_cmp(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_voi
     if args.callout_data.is_null() {
         return ONIG_CALLOUT_FAIL;
     }
+    // SAFETY: non-null was checked above. Whoever stores a non-null
+    // callout_data must point it at the match engine's live callout-data
+    // vector and hold no other reference to it while the callout runs, so
+    // the unique borrow is sound for the duration of this call.
     let cd = unsafe { &mut *args.callout_data };
     let num = args.num;
     if num < 1 {
@@ -1153,6 +1236,9 @@ pub fn onig_builtin_cmp(args: &OnigCalloutArgs, _user_data: *mut std::ffi::c_voi
         return ONIG_CALLOUT_FAIL;
     }
 
+    // SAFETY: args.regex was set in OnigCalloutArgs::new from a `&RegexType`
+    // that the match engine keeps borrowed for as long as it hands these args
+    // to callout functions, so the pointer is valid and aligned here.
     let reg = unsafe { &*args.regex };
     let ext = match reg.extp.as_ref() {
         Some(e) => e,

--- a/src/regparse.rs
+++ b/src/regparse.rs
@@ -2797,6 +2797,12 @@ fn fetch_token(tok: &mut PToken, p: &mut usize, end: usize, pattern: &[u8], env:
                                     } else {
                                         // Named backref: look up name
                                         let name = &pattern[name_start..name_end];
+                                        // SAFETY: `env.reg` was set by `onig_parse_tree`
+                                        // from the `&mut RegexType` borrowed for the
+                                        // entire parse, so it is non-null and live; the
+                                        // parser only reaches the regex through
+                                        // `env.reg`, so no aliasing `&mut` exists while
+                                        // this shared reborrow is used.
                                         let reg = unsafe { &*env.reg };
                                         if let Some(ref nt) = reg.name_table {
                                             if let Some(entry) = nt.find(name) {
@@ -4713,6 +4719,10 @@ fn prs_cc(
 
 /// Allocate a new CalloutListEntry on the regex's ext, return its 1-based num.
 fn reg_callout_list_entry(env: &mut ParseEnv) -> Result<i32, i32> {
+    // SAFETY: `env.reg` was set by `onig_parse_tree` from the `&mut RegexType`
+    // borrowed for the entire parse, so it is non-null and live; we hold the
+    // only `&mut ParseEnv` and the parser reaches the regex only through
+    // `env.reg`, so this exclusive reborrow does not alias any other reference.
     let reg = unsafe { &mut *env.reg };
     if reg.extp.is_none() {
         reg.extp = Some(RegexExt {
@@ -4741,6 +4751,9 @@ fn reg_callout_list_entry(env: &mut ParseEnv) -> Result<i32, i32> {
 
 /// Register a tag name → callout num mapping.
 fn callout_tag_entry(env: &mut ParseEnv, tag: &[u8], num: i32) {
+    // SAFETY: as in `reg_callout_list_entry` above — `env.reg` points to the
+    // `RegexType` mutably borrowed by `onig_parse_tree` for the whole parse,
+    // and no other reference to it is live during this exclusive reborrow.
     let reg = unsafe { &mut *env.reg };
     let ext = reg.extp.as_mut().unwrap();
     if ext.tag_table.is_none() {
@@ -4907,6 +4920,10 @@ fn prs_callout_of_name(
 
     // Create callout list entry
     let num = reg_callout_list_entry(env)?;
+    // SAFETY: `env.reg` was set by `onig_parse_tree` from the `&mut RegexType`
+    // borrowed for the entire parse; the reborrow taken inside
+    // `reg_callout_list_entry` ended when it returned, so this exclusive
+    // reborrow is the only live reference to the regex.
     let reg = unsafe { &mut *env.reg };
     let ext = reg.extp.as_mut().unwrap();
     let entry = &mut ext.callout_list[(num - 1) as usize];
@@ -5085,6 +5102,10 @@ fn prs_callout_of_contents(
 
     // Create entry
     let num = reg_callout_list_entry(env)?;
+    // SAFETY: `env.reg` was set by `onig_parse_tree` from the `&mut RegexType`
+    // borrowed for the entire parse; the reborrow taken inside
+    // `reg_callout_list_entry` ended when it returned, so this exclusive
+    // reborrow is the only live reference to the regex.
     let reg = unsafe { &mut *env.reg };
     let ext = reg.extp.as_mut().unwrap();
     let entry = &mut ext.callout_list[(num - 1) as usize];
@@ -5156,6 +5177,10 @@ fn prs_conditional(
             } else {
                 // Named ref
                 let name = &pattern[name_start..name_end];
+                // SAFETY: `env.reg` was set by `onig_parse_tree` from the
+                // `&mut RegexType` borrowed for the entire parse, so it is
+                // non-null and live; no aliasing `&mut` to the regex exists
+                // while this shared reborrow is used.
                 let reg = unsafe { &*env.reg };
                 let group_nums = if let Some(ref nt) = reg.name_table {
                     nt.name_to_group_numbers(name).map(|s| s.to_vec())
@@ -5989,6 +6014,12 @@ fn prs_bag(
                                     level_val,
                                 )) => {
                                     let name = &pattern[name_start..name_end];
+                                    // SAFETY: `env.reg` was set by
+                                    // `onig_parse_tree` from the
+                                    // `&mut RegexType` borrowed for the entire
+                                    // parse, so it is non-null and live; no
+                                    // aliasing `&mut` to the regex exists
+                                    // while this shared reborrow is used.
                                     let reg = unsafe { &*env.reg };
                                     if let Some(ref nt) = reg.name_table {
                                         if let Some(entry) = nt.find(name) {
@@ -6188,6 +6219,10 @@ fn prs_named_group(
     let num = env.add_mem_entry()?;
 
     // Add to name table
+    // SAFETY: `env.reg` was set by `onig_parse_tree` from the `&mut RegexType`
+    // borrowed for the entire parse, so it is non-null and live; this
+    // exclusive reborrow ends with the `if let` and does not overlap any
+    // other reference to the regex.
     if let Some(ref mut nt) = unsafe { &mut *env.reg }.name_table {
         let name = &pattern[name_start..name_end];
         let allow = is_syntax_bv(env.syntax, ONIG_SYN_ALLOW_MULTIPLEX_DEFINITION_NAME);
@@ -6225,6 +6260,10 @@ struct NamedGroupCtx<'a> {
 
 /// Apply whole options ((?I), (?L), (?C)) to the regex and parse env.
 fn set_whole_options(option: OnigOptionType, env: &mut ParseEnv) {
+    // SAFETY: `env.reg` was set by `onig_parse_tree` from the `&mut RegexType`
+    // borrowed for the entire parse, so it is non-null and live; we hold the
+    // only `&mut ParseEnv` and the parser reaches the regex only through
+    // `env.reg`, so this exclusive reborrow does not alias any other reference.
     let reg = unsafe { &mut *env.reg };
     if option.intersects(ONIG_OPTION_IGNORECASE_IS_ASCII) {
         reg.case_fold_flag &=
@@ -7076,6 +7115,11 @@ fn prs_branch(
     let top = node_new_list(node, None);
     let mut headp: *mut Option<Box<Node>>;
     // We need to build a linked list. Use unsafe pointer to the cdr slot.
+    // SAFETY: `top` is a freshly created `Box<Node>` exclusively owned by this
+    // function; nothing else references it, so casting away constness and
+    // mutating through `top_ptr` cannot conflict with another borrow. `headp`
+    // is derived from the List cell's `cdr` field, which lives in `top`'s
+    // stable heap allocation (a `Box` never moves its contents).
     unsafe {
         let top_ptr = &*top as *const Node as *mut Node;
         if let NodeInner::List(ref mut cons) = (*top_ptr).inner {
@@ -7091,6 +7135,12 @@ fn prs_branch(
         r = r2;
 
         let new_cell = node_new_list(node2, None);
+        // SAFETY: `headp` points at the `cdr` slot of the most recently
+        // appended List cell, which is owned by `top` and kept alive in its
+        // stable heap allocation until this function returns; `prs_exp` above
+        // does not touch `top`, so the slot is still valid. Writing the new
+        // cell and then re-deriving `headp` from it happens while no other
+        // reference into the list exists.
         unsafe {
             *headp = Some(new_cell);
             // Advance headp to the new cell's cdr
@@ -7133,6 +7183,12 @@ fn prs_alts(
     } else if r == TokenType::Alt as i32 {
         let top = node_new_alt(node, None);
         let mut headp: *mut Option<Box<Node>>;
+        // SAFETY: `top` is a freshly created `Box<Node>` exclusively owned by
+        // this function; nothing else references it, so casting away
+        // constness and mutating through `top_ptr` cannot conflict with
+        // another borrow. `headp` is derived from the Alt cell's `cdr` field,
+        // which lives in `top`'s stable heap allocation (a `Box` never moves
+        // its contents).
         unsafe {
             let top_ptr = &*top as *const Node as *mut Node;
             if let NodeInner::Alt(ref mut cons) = (*top_ptr).inner {
@@ -7152,6 +7208,13 @@ fn prs_alts(
             r = r2;
 
             let new_cell = node_new_alt(node2, None);
+            // SAFETY: `headp` points at the `cdr` slot of the most recently
+            // appended Alt cell, which is owned by `top` and kept alive in
+            // its stable heap allocation until this function returns;
+            // `fetch_token`/`prs_branch` above do not touch `top`, so the
+            // slot is still valid. Writing the new cell and then re-deriving
+            // `headp` from it happens while no other reference into the list
+            // exists.
             unsafe {
                 *headp = Some(new_cell);
                 if let Some(ref mut cell) = *headp {
@@ -7224,8 +7287,18 @@ pub fn onig_parse_tree(
     env.options = reg.options;
     env.case_fold_flag = reg.case_fold_flag;
     env.enc = reg.enc;
+    // SAFETY: `reg.syntax` is always set from a `&'static OnigSyntaxType`
+    // (the built-in `static` syntaxes in regsyntax.rs, or a caller-provided
+    // 'static syntax via the API builder), mirroring C Oniguruma where syntax
+    // definitions are global. It is therefore non-null, properly aligned, and
+    // valid for the 'static lifetime claimed by `env.syntax`. A caller that
+    // stored a dangling or non-'static pointer in `reg.syntax` would break
+    // this invariant.
     env.syntax = unsafe { &*reg.syntax };
     env.pattern = pattern.as_ptr();
+    // SAFETY: offsetting the slice's base pointer by its own length yields
+    // the one-past-the-end pointer of the same allocation, which `add`
+    // permits; the result is used only as an end sentinel, never dereferenced.
     env.pattern_end = unsafe { pattern.as_ptr().add(pattern.len()) };
     env.reg = reg as *mut RegexType;
 

--- a/src/regparse_types.rs
+++ b/src/regparse_types.rs
@@ -447,8 +447,25 @@ impl Node {
     }
 }
 
-// Allow sending Node across threads (raw pointers require manual impl)
+// Raw pointers require manual Send/Sync impls.
+//
+// SAFETY: the raw pointers in a Node (`parent`, and `CallNode::target_node`)
+// are non-owning links to other nodes inside the same AST, which is owned as
+// a single `Box<Node>` tree. Sending the tree to another thread transfers all
+// of the pointees along with it, so the internal pointers stay valid and no
+// two threads ever own the same node. This would break if a Node were sent
+// while its `parent`/`target_node` pointed into a tree left behind on the
+// original thread — the parser never does that: trees are built, compiled,
+// and dropped whole.
 unsafe impl Send for Node {}
+// SAFETY: no safe method dereferences the raw pointers, so `&Node` shared
+// between threads permits no data race through them; any dereference happens
+// in crate-internal unsafe code during parse/compile, which is single-threaded
+// (the tree is confined to the one thread running onig_new-style compilation).
+// Note this impl is trusting rather than airtight: `parent`/`target_node` can
+// alias other nodes in the same tree, so unsafe code that mutated through them
+// while another thread held any `&Node` into the tree would be a data race.
+// Kept to mirror the C code, where node trees are likewise thread-confined.
 unsafe impl Sync for Node {}
 
 // === Node Variant Structs ===
@@ -761,8 +778,18 @@ impl Default for MemEnv {
     }
 }
 
-// Safety: MemEnv contains raw pointers that are only used within the parser
+// SAFETY: `mem_node` and `empty_repeat_node` are non-owning pointers to
+// BAG_MEMORY / quantifier nodes inside the parse tree of the regex currently
+// being compiled. A MemEnv lives inside a ParseEnv, which exists only for the
+// duration of a single-threaded parse/compile pass and is never handed to
+// another thread while those pointers are live (they dangle once the tree is
+// dropped). Sending a MemEnv with live pointers to a thread that outlives the
+// tree would break this invariant.
 unsafe impl Send for MemEnv {}
+// SAFETY: nothing dereferences these pointers through `&MemEnv` outside the
+// single compilation thread; sharing across threads never happens in practice
+// because the owning ParseEnv is parser-scoped. Concurrent mutation of the
+// pointees from another thread would be a data race and would break this.
 unsafe impl Sync for MemEnv {}
 
 // === Save Item ===
@@ -778,8 +805,16 @@ pub struct UnsetAddr {
     pub target: *mut Node,
 }
 
-// Safety: UnsetAddr contains raw pointers used within the parser
+// SAFETY: `target` is a non-owning pointer to a BAG_MEMORY node in the parse
+// tree, recorded so the compiler can patch call addresses later in the same
+// compilation pass. The list of UnsetAddr entries lives in the parser-scoped
+// ParseEnv and is consumed on the same thread before the tree is dropped;
+// sending an entry to a thread that outlives the tree would break this.
 unsafe impl Send for UnsetAddr {}
+// SAFETY: `target` is never dereferenced through `&UnsetAddr` outside the
+// single compilation thread, and UnsetAddr values are not shared across
+// threads in practice (parser-scoped, single-threaded use during
+// compilation). Concurrent mutation of the pointee would be a data race.
 unsafe impl Sync for UnsetAddr {}
 
 // === Parse Environment (ScanEnv in C) ===
@@ -813,8 +848,21 @@ pub struct ParseEnv {
     pub flags: u32,
 }
 
-// Safety: ParseEnv contains raw pointers used within the parser scope
+// SAFETY: the raw pointers in ParseEnv point into data owned by the caller of
+// `onig_parse_tree` for the whole compilation: `pattern`/`pattern_end` (and
+// `error`/`error_end`) into the pattern bytes, `reg` at the RegexType under
+// construction, and the MemEnv slots into the parse tree. A ParseEnv is
+// created per compilation, used on that one thread, and discarded; moving it
+// to another thread is only sound while pattern, regex, and tree are moved or
+// kept alive with it. Sending a ParseEnv beyond the lifetime of those
+// referents would break this invariant.
 unsafe impl Send for ParseEnv {}
+// SAFETY: ParseEnv is never shared across threads in practice — parsing is
+// strictly single-threaded and every function takes `&mut ParseEnv`, so no
+// concurrent access through `&ParseEnv` occurs. This impl is trusting rather
+// than airtight: `reg` is a mutably-dereferenced interior pointer, so two
+// threads holding `&ParseEnv` and dereferencing `reg` (as the parser's unsafe
+// blocks do) would race. Kept to mirror the C code's thread-confined ScanEnv.
 unsafe impl Sync for ParseEnv {}
 
 // === Node Creation Helper Functions ===


### PR DESCRIPTION
Third audit batch — the unsafe audit. ADR-002 states the policy; this PR enforces it at every call site.

## What changed

- **All 94 undocumented unsafe sites** (52 in `regcomp.rs`, 22 in `regexec.rs`, 15 in `regparse.rs`, 5 `unsafe impl Send/Sync` in `regparse_types.rs`) now carry `SAFETY:` comments stating the actual invariant — pointer provenance and liveness, bounds reasoning, MARK1/MARK2 cycle guards — referencing the code that establishes it. Contracts that are not locally verifiable are called out explicitly rather than papered over (e.g. the currently-unreachable callout-data branches whose soundness binds future writers, and the two `Sync` impls that mirror C Oniguruma's thread-confined parser structures and are honestly marked as trusting rather than airtight).
- **The three fn-pointer transmutes** in the callout accessors gain explicit `transmute::<*mut (), OnigCalloutFunc>` annotations plus SAFETY comments. They are `AtomicPtr` round-trips of function pointers, not the unbounded-lifetime pattern they resembled at first glance.
- **Crate-level lint hygiene**: `#[allow(clippy::missing_transmute_annotations)]` is gone (fixed at the source), `#[allow(clippy::not_unsafe_ptr_arg_deref)]` is gone (it no longer suppressed anything), and the crate root now carries `#[deny(unsafe_op_in_unsafe_fn)]` plus `#[warn(clippy::undocumented_unsafe_blocks)]` so new unsafe cannot land undocumented.

## What did not change

Behavior. The only removed lines are the two stale allows and the three annotated transmutes; everything else is comment insertions (415 lines). Full suite passing locally: lib 235, api_test 148, doctests 10, compat_syntax/options/regset 106, compat_utf8 1,568, compat_back 26 — plus fmt and the CI clippy gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD

---
_Generated by [Claude Code](https://claude.ai/code/session_014siFDKatCAzTaNStN1DxGD)_